### PR TITLE
Use a factory method to create instances of the cache

### DIFF
--- a/EveLib.Core/Config.cs
+++ b/EveLib.Core/Config.cs
@@ -2,6 +2,7 @@
 using System.Configuration;
 using System.Globalization;
 using System.IO;
+using eZet.EveLib.Core.Cache;
 
 namespace eZet.EveLib.Core {
     /// <summary>
@@ -18,6 +19,11 @@ namespace eZet.EveLib.Core {
         /// </summary>
         public static readonly string AppData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) +
                                                 Separator;
+
+        /// <summary>
+        ///     The cache factory
+        /// </summary>
+        public static Func<IEveLibCache> CacheFactory;
 
         /// <summary>
         ///     Filename for the Cache Register
@@ -48,6 +54,7 @@ namespace eZet.EveLib.Core {
             if (String.IsNullOrEmpty(UserAgent))
                 UserAgent = "EveLib";
             string appName = ConfigurationManager.AppSettings["eveLib.AppData"];
+            CacheFactory = () => new EveLibFileCache();
             AppData += !string.IsNullOrEmpty(appName) ? appName : "EveLib";
             CachePath = AppData + Separator + "Cache";
             ImagePath = AppData + Separator + "Images";

--- a/EveLib.EveOnline/BaseEntity.cs
+++ b/EveLib.EveOnline/BaseEntity.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.Contracts;
 using System.Threading.Tasks;
+using eZet.EveLib.Core;
 using eZet.EveLib.Core.Cache;
 using eZet.EveLib.Core.RequestHandlers;
 using eZet.EveLib.Core.Serializers;
@@ -20,7 +21,7 @@ namespace eZet.EveLib.Modules {
         protected BaseEntity() {
             var handler = new EveOnlineRequestHandler();
             handler.Serializer = new XmlSerializer();
-            handler.Cache = new EveLibFileCache();
+            handler.Cache = Config.CacheFactory();
             RequestHandler = handler;
             BaseUri = DefaultUri;
             EnableCacheLoad = true;

--- a/EveLib.ZKillboard/ZKillboard.cs
+++ b/EveLib.ZKillboard/ZKillboard.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.Contracts;
 using System.Threading.Tasks;
-using eZet.EveLib.Core.Cache;
+using eZet.EveLib.Core;
 using eZet.EveLib.Core.RequestHandlers;
 using eZet.EveLib.Core.Serializers;
 using eZet.EveLib.Modules.Models;
@@ -21,7 +21,7 @@ namespace eZet.EveLib.Modules {
         /// Default constructor
         /// </summary>
         public ZKillboard() {
-            RequestHandler = new ZkbRequestHandler(new JsonSerializer(), new EveLibFileCache());
+            RequestHandler = new ZkbRequestHandler(new JsonSerializer(), Config.CacheFactory());
             BaseUri = new Uri(DefaultUri);
         }
 


### PR DESCRIPTION
Currently, it's not possible to use a custom implementation of
IEveLibCache without chaning the code in BaseEntity.
This will allow users to provide a custom factory method to use their
implementation if needed.
