### PR TITLE
Add / to front of "solarSystemID" and "regionID"

### DIFF
--- a/EveLib.ZKillboard/ZKillboardOptions.cs
+++ b/EveLib.ZKillboard/ZKillboardOptions.cs
@@ -226,9 +226,9 @@ namespace eZet.EveLib.ZKillboardModule {
             if (GroupId.Count != 0)
                 queryString += "/groupID/" + string.Join(",", GroupId);
             if (SolarsystemId.Count != 0)
-                queryString += "solarSystemID/" + string.Join(",", SolarsystemId);
+                queryString += "/solarSystemID/" + string.Join(",", SolarsystemId);
             if (RegionId.Count != 0)
-                queryString += "regionID/" + string.Join(",", RegionId);
+                queryString += "/regionID/" + string.Join(",", RegionId);
 
             if (StartTime != null)
                 queryString += "/startTime/" + StartTime.Value.ToString("yyyyMMddHHmm");


### PR DESCRIPTION
Added a / to the front of the "solarSystemID" and "regionID" queryString so Zkillboard will process that correctly.