### PR TITLE
Properly map CharacterName to Account/Characters XML

### DIFF
--- a/EveLib.EveXml/Models/Account/CharacterList.cs
+++ b/EveLib.EveXml/Models/Account/CharacterList.cs
@@ -37,7 +37,7 @@ namespace eZet.EveLib.EveXmlModule.Models.Account {
             ///     Gets or sets the name of the character.
             /// </summary>
             /// <value>The name of the character.</value>
-            [XmlAttribute("characterName")]
+            [XmlAttribute("name")]
             public string CharacterName { get; set; }
 
             /// <summary>


### PR DESCRIPTION
Account/Characters.xml.aspx API call uses the *name* attribute, not *characterName* for the character name.