### PR TITLE
Fix API Access mask overflowing on new masks

### DIFF
--- a/EveLib.EveXml/ApiKey.cs
+++ b/EveLib.EveXml/ApiKey.cs
@@ -95,7 +95,7 @@ namespace eZet.EveLib.EveXmlModule {
         ///     Gets the CAK access mask of this key. Note: If this object has not already been initialized, this will send a web
         ///     request to the API.
         /// </summary>
-        public int AccessMask {
+        public long AccessMask {
             get { return ApiKeyInfo.AccessMask; }
         }
 

--- a/EveLib.EveXml/Models/Account/ApiKeyInfo.cs
+++ b/EveLib.EveXml/Models/Account/ApiKeyInfo.cs
@@ -46,7 +46,7 @@ namespace eZet.EveLib.EveXmlModule.Models.Account {
             /// </summary>
             /// <value>The access mask.</value>
             [XmlAttribute("accessMask")]
-            public int AccessMask { get; set; }
+            public long AccessMask { get; set; }
 
             /// <summary>
             ///     Gets or sets the type.

--- a/EveLib.EveXml/Models/Misc/CallList.cs
+++ b/EveLib.EveXml/Models/Misc/CallList.cs
@@ -87,7 +87,7 @@ namespace eZet.EveLib.EveXmlModule.Models.Misc {
             /// </summary>
             /// <value>The access mask.</value>
             [XmlAttribute("accessMask")]
-            public int AccessMask { get; set; }
+            public long AccessMask { get; set; }
 
             /// <summary>
             ///     Gets or sets the character.


### PR DESCRIPTION
They're getting above 2 billion now and was causing crashes, thought I'd make it a long and hopefully it wont happen again.