### PR TITLE
Remove redundant call to JsonConvert.DeserializeObject

### DIFF
--- a/EveLib.DynamicCrest/JsonSerializer.cs
+++ b/EveLib.DynamicCrest/JsonSerializer.cs
@@ -70,7 +70,6 @@ namespace eZet.EveLib.DynamicCrest {
         public T Deserialize<T>(string data) {
             _trace.TraceEvent(TraceEventType.Verbose, 0, "JsonSerializer.Deserialize:Start");
             dynamic result = JsonConvert.DeserializeObject<T>(data, Settings);
-            var res = JsonConvert.DeserializeObject(data, Settings);
             _trace.TraceEvent(TraceEventType.Verbose, 0, "JsonSerializer.Deserialize:Complete");
             return result;
         }


### PR DESCRIPTION
The string is being deserialized twice, the second time the result is not being used, therefore can be deleted.  I guess was debugging code or something.